### PR TITLE
MVR-290 Random Recipe Previews on Homepage

### DIFF
--- a/src/main/java/com/lstierneyltd/recipebackend/controller/RecipeRestController.java
+++ b/src/main/java/com/lstierneyltd/recipebackend/controller/RecipeRestController.java
@@ -23,7 +23,7 @@ public interface RecipeRestController {
 
     List<RecipeRepository.RecipePreview> getLatestRecipes();
 
-    RecipeRepository.RecipePreview getRandomRecipe();
+    List<RecipeRepository.RecipePreview> getRandomRecipes();
 
     Recipe markRecipeAsCooked(Integer id);
 }

--- a/src/main/java/com/lstierneyltd/recipebackend/controller/RecipeRestControllerImpl.java
+++ b/src/main/java/com/lstierneyltd/recipebackend/controller/RecipeRestControllerImpl.java
@@ -45,7 +45,7 @@ public class RecipeRestControllerImpl implements RecipeRestController {
 
     @Override
     @GetMapping("/random")
-    public RecipeRepository.RecipePreview getRandomRecipe() {
+    public List<RecipeRepository.RecipePreview> getRandomRecipes() {
         return recipeService.findRandom();
     }
 

--- a/src/main/java/com/lstierneyltd/recipebackend/repository/RecipeRepository.java
+++ b/src/main/java/com/lstierneyltd/recipebackend/repository/RecipeRepository.java
@@ -17,8 +17,8 @@ public interface RecipeRepository extends JpaRepository<Recipe, Integer> {
     List<Recipe> findByAllTagNames(List<String> tagNames, Long tagCount);
 
 
-    @Query("SELECT r FROM Recipe r ORDER BY RAND() LIMIT 1")
-    Optional<RecipePreview> findRecipePreviewOrderByRand();
+    @Query("SELECT r FROM Recipe r ORDER BY RAND() LIMIT 6")
+    List<RecipePreview> findRecipePreviewsOrderByRand();
 
     List<RecipePreview> findTop6RecipePreviewByOrderByIdDesc();
 

--- a/src/main/java/com/lstierneyltd/recipebackend/service/RecipeService.java
+++ b/src/main/java/com/lstierneyltd/recipebackend/service/RecipeService.java
@@ -21,7 +21,7 @@ public interface RecipeService {
 
     List<RecipeRepository.RecipePreview> findLatest();
 
-    RecipeRepository.RecipePreview findRandom();
+    List<RecipeRepository.RecipePreview> findRandom();
 
     Recipe markAsCooked(Integer id);
 }

--- a/src/main/java/com/lstierneyltd/recipebackend/service/RecipeServiceImpl.java
+++ b/src/main/java/com/lstierneyltd/recipebackend/service/RecipeServiceImpl.java
@@ -84,8 +84,8 @@ public class RecipeServiceImpl implements RecipeService {
     }
 
     @Override
-    public RecipeRepository.RecipePreview findRandom() {
-        return recipeRepository.findRecipePreviewOrderByRand().orElseThrow(() -> new ResourceNotFoundException(COULD_NOT_FIND_RANDOM_RECIPE));
+    public List<RecipeRepository.RecipePreview> findRandom() {
+        return recipeRepository.findRecipePreviewsOrderByRand();
     }
 
     @Override

--- a/src/test/java/com/lstierneyltd/recipebackend/controller/RecipeRestControllerImplTest.java
+++ b/src/test/java/com/lstierneyltd/recipebackend/controller/RecipeRestControllerImplTest.java
@@ -113,9 +113,9 @@ public class RecipeRestControllerImplTest {
     }
 
     @Test
-    public void testGetRandomRecipe() {
+    public void testGetRandomRecipes() {
         // when
-        recipeRestController.getRandomRecipe();
+        recipeRestController.getRandomRecipes();
 
         // then
         then(recipeService).should().findRandom();

--- a/src/test/java/com/lstierneyltd/recipebackend/integration/RestIntegrationTests.java
+++ b/src/test/java/com/lstierneyltd/recipebackend/integration/RestIntegrationTests.java
@@ -368,4 +368,16 @@ public class RestIntegrationTests {
 
         assertThat(recipe.getCooked(), is(3));
     }
+
+    @Test
+    @Order(60)
+    public void testGetRandomRecipes() {
+        ResponseEntity<RecipePreviewImpl[]> response = testRestTemplate.getForEntity("/api/recipes/random", RecipePreviewImpl[].class);
+
+        // Good status?
+        verifyStatusOk(response.getStatusCode());
+
+        RecipeRepository.RecipePreview[] previews = requireNonNull(response.getBody());
+        assertThat(previews.length, is(6));
+    }
 }

--- a/src/test/java/com/lstierneyltd/recipebackend/service/RecipeServiceImplTest.java
+++ b/src/test/java/com/lstierneyltd/recipebackend/service/RecipeServiceImplTest.java
@@ -221,27 +221,14 @@ public class RecipeServiceImplTest {
     public void findRandom() {
         // Given
         RecipePreviewImpl recipePreview = getRecipePreview();
-        given(recipeRepository.findRecipePreviewOrderByRand()).willReturn(Optional.of(recipePreview));
+        given(recipeRepository.findRecipePreviewsOrderByRand()).willReturn(List.of(recipePreview));
 
         // when
-        RecipeRepository.RecipePreview random = recipeService.findRandom();
+        List<RecipeRepository.RecipePreview> random = recipeService.findRandom();
 
         // then
-        then(recipeRepository).should().findRecipePreviewOrderByRand();
-        assertThat(random, equalTo(recipePreview));
-    }
-
-    @Test
-    public void findRandom_notFound() {
-        // Given
-        given(recipeRepository.findRecipePreviewOrderByRand()).willReturn(Optional.empty());
-
-        // When
-        Exception exception = assertThrows(ResourceNotFoundException.class, () -> recipeService.findRandom());
-
-        // Then
-        then(recipeRepository).should().findRecipePreviewOrderByRand();
-        assertThat(exception.getMessage(), equalTo(COULD_NOT_FIND_RANDOM_RECIPE));
+        then(recipeRepository).should().findRecipePreviewsOrderByRand();
+        assertThat(random.get(0), equalTo(recipePreview));
     }
 
     @Test


### PR DESCRIPTION
Updated method to return multiple random recipes

Previously, the method `findRandom` would return a single random recipe. This was limiting for cases where multiple random recipes were required. It has been updated to return a list of random recipes instead. Changes were made in repository queries, service layer interfaces and implementation classes, and controllers. Corresponding changes were made in tests as well to ensure proper verification of the updated functionality. The number of random recipes returned has been set to 6.