### PR TITLE
MVR-294 FIXED bug where last_cooked was being overwritten on Recipe u…

### DIFF
--- a/src/main/java/com/lstierneyltd/recipebackend/service/RecipeServiceImpl.java
+++ b/src/main/java/com/lstierneyltd/recipebackend/service/RecipeServiceImpl.java
@@ -46,26 +46,6 @@ public class RecipeServiceImpl implements RecipeService {
         return newRecipe;
     }
 
-    /*
-    Recipe{" +
-              private int id;
-    private String name;
-    private String description;
-    private String imageFileName;
-    private int cooked;
-    private LocalDateTime lastCooked;
-    private int cookingTime;
-    private String basedOn;
-    private List<MethodStep> methodSteps = new ArrayList<>();
-    private List<Ingredient> ingredients = new ArrayList<>();
-    private List<Note> notes = new ArrayList<>();
-    private Set<Tag> tags = new HashSet<>();
-    private ServedOn servedOn;
-    private LocalDateTime createdDate;
-    private LocalDateTime lastUpdatedDate;
-    private String createdBy;
-    private String lastUpdatedBy;
-     */
     @Override
     public Recipe updateRecipe(MultipartFile imageFile, String recipeString) {
         final Recipe submittedRecipe = objectMapperService.jsonStringToObject(recipeString, Recipe.class);
@@ -79,8 +59,6 @@ public class RecipeServiceImpl implements RecipeService {
             existingRecipe.setName(submittedRecipe.getName());
             existingRecipe.setDescription(submittedRecipe.getDescription());
             existingRecipe.setImageFileName(submittedRecipe.getImageFileName());
-            existingRecipe.setCooked(submittedRecipe.getCooked());
-            existingRecipe.setLastCooked(submittedRecipe.getLastCooked());
             existingRecipe.setCookingTime(submittedRecipe.getCookingTime());
             existingRecipe.setBasedOn(submittedRecipe.getBasedOn());
 

--- a/src/test/java/com/lstierneyltd/recipebackend/service/RecipeServiceImplTest.java
+++ b/src/test/java/com/lstierneyltd/recipebackend/service/RecipeServiceImplTest.java
@@ -109,13 +109,18 @@ public class RecipeServiceImplTest {
     @Test
     public void updateRecipe() {
         String json = "JSON String";
-        Recipe submittedRecipe = getRecipe();
+
+        final Recipe updateDatedRecipe = getRecipe();
         String newDescription = "This is the new description";
-        submittedRecipe.setDescription(newDescription);
-        Recipe existingRecipe = getRecipe();
+        updateDatedRecipe.setDescription(newDescription);
+        updateDatedRecipe.setCooked(100);
+
+        final Recipe existingRecipe = getRecipe();
+        existingRecipe.setLastCooked(LAST_COOKED);
+        existingRecipe.setCooked(COOKED);
 
         // given
-        given(objectMapperService.jsonStringToObject(json, Recipe.class)).willReturn(submittedRecipe);
+        given(objectMapperService.jsonStringToObject(json, Recipe.class)).willReturn(updateDatedRecipe);
         given(recipeRepository.findById(ID)).willReturn(Optional.of(existingRecipe));
         given(recipeRepository.save(existingRecipe)).willReturn(existingRecipe);
         given(userService.getLoggedInUsername()).willReturn(USER_NAME);
@@ -134,6 +139,8 @@ public class RecipeServiceImplTest {
         assertThat(updatedRecipe.getDescription(), is(newDescription));
         assertThat(updatedRecipe.getLastUpdatedBy(), is("lawrence"));
         assertTrue(TestUtils.areWithinSeconds(updatedRecipe.getLastUpdatedDate(), LocalDateTime.now(), 10));
+        assertThat(updatedRecipe.getCooked(), is(COOKED));
+        assertThat(updatedRecipe.getLastCooked(), is(LAST_COOKED));
     }
 
     @Test


### PR DESCRIPTION
…pdate

Remove unnecessary fields in RecipeServiceImpl

The code contains a commented block that shows a theoretical structure of the Recipe model that is not needed, thus cluttered the code. Unnecessary setter methods for "cooked" and "lastCooked" fields have been removed in the 'updateRecipe' function. This is done because the values for these fields are not updated through this method. Corresponding changes have been reflected in the RecipeServiceImplTest as well.