### PR TITLE
MVR-303 Add cache control to /images

### DIFF
--- a/src/main/java/com/lstierneyltd/recipebackend/config/WebConfig.java
+++ b/src/main/java/com/lstierneyltd/recipebackend/config/WebConfig.java
@@ -1,0 +1,19 @@
+package com.lstierneyltd.recipebackend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.CacheControl;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/images/**")
+                .addResourceLocations("file:/opt/recipe-website/images/")
+                .setCacheControl(CacheControl.maxAge(365, TimeUnit.DAYS).cachePublic());
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.profiles.active=dev
 server.port=8080
 spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=none
-spring.web.resources.static-locations=file:/opt/recipe-website
+#spring.web.resources.static-locations=file:/opt/recipe-website
 file.upload.directory=/opt/recipe-website/
 jwt.secret=${JWT_SECRET}
 # One day


### PR DESCRIPTION
Add WebConfig class for resource handling and cache control

A new WebConfig class has been added to manage resource handling, specifically for '/images' using Spring's WebMvcConfigurer interface. The configuration implements cache control for a maximum age of 365 days. Additionally, the 'spring.web.resources.static-locations' line in the application.properties file has been commented out.