### PR TITLE
MVR-308 Fix case sensitivity in SQL queries for recipe table

### DIFF
--- a/src/main/java/com/lstierneyltd/recipebackend/repository/RecipeRepository.java
+++ b/src/main/java/com/lstierneyltd/recipebackend/repository/RecipeRepository.java
@@ -28,10 +28,10 @@ public interface RecipeRepository extends JpaRepository<Recipe, Integer> {
     Optional<Recipe> findByName(String name);
 
     // Need to use nativeQuery here because otherwise the @where on the entity will be honoured
-    @Query(value = "SELECT * FROM Recipe r WHERE r.id = :id", nativeQuery = true)
+    @Query(value = "SELECT * FROM recipe r WHERE r.id = :id", nativeQuery = true)
     Optional<Recipe> findByIdIgnoreDeleted(Integer id);
 
-    @Query(value = "SELECT * FROM Recipe r", nativeQuery = true)
+    @Query(value = "SELECT * FROM recipe r", nativeQuery = true)
     List<Recipe> findAllIgnoreDeleted();
 
     /**


### PR DESCRIPTION
Updated native SQL queries in RecipeRepository to ensure consistent table naming by setting `recipe` in lowercase. This change prevents potential errors on case-sensitive databases and improves compatibility across environments.