### PR TITLE
MVR-308 Refactor to ensure active recipe handling across services

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.3</version>
+        <version>3.1.4</version> <!-- Latest version as of now -->
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.lstierneyltd</groupId>
@@ -19,7 +19,7 @@
         <java.version>17</java.version>
         <jjwt.version>0.9.1</jjwt.version>
         <pitest.version>1.14.2</pitest.version>
-        <mysql-connector-j.version>8.0.32</mysql-connector-j.version>
+        <mysql-connector-j.version>9.2.0</mysql-connector-j.version>
         <spring-boot-test-autoconfigure.version>3.0.3</spring-boot-test-autoconfigure.version>
         <maven-surefire-plugin.version>3.0.0-M9</maven-surefire-plugin.version>
         <maven-site-plugin.version>3.12.1</maven-site-plugin.version>

--- a/src/main/java/com/lstierneyltd/recipebackend/controller/RecipeRestController.java
+++ b/src/main/java/com/lstierneyltd/recipebackend/controller/RecipeRestController.java
@@ -11,7 +11,7 @@ public interface RecipeRestController {
 
     Recipe getRecipeByName(String name);
 
-    List<Recipe> getAllRecipes();
+    List<Recipe> getAllActiveRecipes();
 
     Recipe addRecipe(MultipartFile imageFile, String recipe);
 

--- a/src/main/java/com/lstierneyltd/recipebackend/controller/RecipeRestControllerImpl.java
+++ b/src/main/java/com/lstierneyltd/recipebackend/controller/RecipeRestControllerImpl.java
@@ -63,14 +63,14 @@ public class RecipeRestControllerImpl implements RecipeRestController {
 
     @Override
     @GetMapping
-    public List<Recipe> getAllRecipes() {
-        return recipeService.findAll();
+    public List<Recipe> getAllActiveRecipes() {
+        return recipeService.findAllActive();
     }
 
     @Override
     @GetMapping("/list")
     public List<RecipeRepository.RecipePreview> getRecipesPreviewList() {
-        return recipeService.findAllRecipePreviewBy();
+        return recipeService.findAllRecipePreview();
     }
 
     @Override
@@ -100,6 +100,6 @@ public class RecipeRestControllerImpl implements RecipeRestController {
     @Override
     @GetMapping("/listIgnoreDeleted")
     public List<Recipe> getAllRecipesIgnoreDeleted() {
-        return recipeService.findAllIgnoreDeleted();
+        return recipeService.findAll();
     }
 }

--- a/src/main/java/com/lstierneyltd/recipebackend/entities/Recipe.java
+++ b/src/main/java/com/lstierneyltd/recipebackend/entities/Recipe.java
@@ -3,7 +3,6 @@ package com.lstierneyltd.recipebackend.entities;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.lstierneyltd.recipebackend.annotation.Generated;
 import jakarta.persistence.*;
-import org.hibernate.annotations.Where;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -17,7 +16,6 @@ import java.util.Set;
         catalog = "recipes",
         uniqueConstraints = @UniqueConstraint(columnNames = "name")
 )
-@Where(clause = "deleted != 1")
 public class Recipe extends Auditable implements java.io.Serializable {
     private int id;
     private String name;

--- a/src/main/java/com/lstierneyltd/recipebackend/repository/RecipeRepository.java
+++ b/src/main/java/com/lstierneyltd/recipebackend/repository/RecipeRepository.java
@@ -9,30 +9,29 @@ import java.util.List;
 import java.util.Optional;
 
 public interface RecipeRepository extends JpaRepository<Recipe, Integer> {
-    List<RecipePreview> findAllRecipePreviewBy();
+
+    @Query("SELECT r FROM Recipe r WHERE r.deleted = false")
+    List<RecipePreview> findAllActiveRecipePreviews();
 
     @Query("SELECT r FROM Recipe r " +
-            "WHERE (SELECT COUNT(t) FROM r.tags t WHERE t.name IN :tagNames) = :tagCount " +
+            "WHERE ((SELECT COUNT(t) FROM r.tags t WHERE t.name IN :tagNames) = :tagCount) AND (r.deleted = false) " +
             "ORDER BY r.lastCooked ASC")
-    List<Recipe> findByAllTagNames(List<String> tagNames, Long tagCount);
+    List<Recipe> findByAllActiveRecipesByTagNames(List<String> tagNames, Long tagCount);
 
-    @Query("SELECT r FROM Recipe r JOIN r.tags t WHERE t.name = 'dinner' ORDER BY RAND() LIMIT 6")
-    List<RecipePreview> findRandomDinners();
+    @Query("SELECT r FROM Recipe r JOIN r.tags t WHERE t.name = 'dinner' AND r.deleted = false ORDER BY RAND() LIMIT 6")
+    List<RecipePreview> findSixRandomActiveDinners();
 
-    @Query("SELECT r FROM Recipe r JOIN r.tags t WHERE t.name = 'dinner' ORDER BY RAND() LIMIT 1")
-    RecipePreview findRandomDinner();
+    @Query("SELECT r FROM Recipe r JOIN r.tags t WHERE t.name = 'dinner' AND r.deleted = false ORDER BY RAND() LIMIT 1")
+    RecipePreview findRandomActiveDinner();
 
-    List<RecipePreview> findTop6RecipePreviewByOrderByIdDesc();
+    @Query("SELECT r FROM Recipe r JOIN r.tags t WHERE t.name = 'dinner' AND r.deleted = false ORDER BY r.id desc LIMIT 6")
+    List<RecipePreview> findSixLatestActiveDinnerPreviews();
 
-    @Query("SELECT r FROM Recipe r WHERE lower(r.name) = ?1")
-    Optional<Recipe> findByName(String name);
+    @Query("SELECT r FROM Recipe r WHERE lower(r.name) = ?1 AND r.deleted = false")
+    Optional<Recipe> findActiveByName(String name);
 
-    // Need to use nativeQuery here because otherwise the @where on the entity will be honoured
-    @Query(value = "SELECT * FROM recipe r WHERE r.id = :id", nativeQuery = true)
-    Optional<Recipe> findByIdIgnoreDeleted(Integer id);
-
-    @Query(value = "SELECT * FROM recipe r", nativeQuery = true)
-    List<Recipe> findAllIgnoreDeleted();
+    @Query("SELECT r FROM Recipe r WHERE r.deleted = false")
+    List<Recipe> findActiveRecipes();
 
     /**
      * This is a "Projection"

--- a/src/main/java/com/lstierneyltd/recipebackend/service/RecipeService.java
+++ b/src/main/java/com/lstierneyltd/recipebackend/service/RecipeService.java
@@ -17,9 +17,11 @@ public interface RecipeService {
 
     List<Recipe> findByTagNames(List<String> tagNames);
 
+    List<Recipe> findAllActive();
+
     List<Recipe> findAll();
 
-    List<RecipeRepository.RecipePreview> findAllRecipePreviewBy();
+    List<RecipeRepository.RecipePreview> findAllRecipePreview();
 
     List<RecipeRepository.RecipePreview> findLatest();
 
@@ -32,7 +34,5 @@ public interface RecipeService {
     Recipe markAsDeleted(Integer id);
 
     Recipe restore(Integer id);
-
-    List<Recipe> findAllIgnoreDeleted();
 }
 

--- a/src/main/java/com/lstierneyltd/recipebackend/service/RecipeServiceImpl.java
+++ b/src/main/java/com/lstierneyltd/recipebackend/service/RecipeServiceImpl.java
@@ -104,7 +104,7 @@ public class RecipeServiceImpl implements RecipeService {
     @Override
     public Recipe findByName(String name) {
         String formattedName = getFormattedRecipeName(name);
-        return recipeRepository.findByName(formattedName).orElseThrow(() -> new ResourceNotFoundException(COULD_NOT_FIND_RECIPE_WITH_NAME + formattedName));
+        return recipeRepository.findActiveByName(formattedName).orElseThrow(() -> new ResourceNotFoundException(COULD_NOT_FIND_RECIPE_WITH_NAME + formattedName));
     }
 
     private String getFormattedRecipeName(String name) {
@@ -113,7 +113,12 @@ public class RecipeServiceImpl implements RecipeService {
 
     @Override
     public List<Recipe> findByTagNames(List<String> tagNames) {
-        return recipeRepository.findByAllTagNames(tagNames, (long) tagNames.size());
+        return recipeRepository.findByAllActiveRecipesByTagNames(tagNames, (long) tagNames.size());
+    }
+
+    @Override
+    public List<Recipe> findAllActive() {
+        return recipeRepository.findActiveRecipes();
     }
 
     @Override
@@ -121,24 +126,25 @@ public class RecipeServiceImpl implements RecipeService {
         return recipeRepository.findAll();
     }
 
+
     @Override
-    public List<RecipeRepository.RecipePreview> findAllRecipePreviewBy() {
-        return recipeRepository.findAllRecipePreviewBy();
+    public List<RecipeRepository.RecipePreview> findAllRecipePreview() {
+        return recipeRepository.findAllActiveRecipePreviews();
     }
 
     @Override
     public List<RecipeRepository.RecipePreview> findLatest() {
-        return recipeRepository.findTop6RecipePreviewByOrderByIdDesc();
+        return recipeRepository.findSixLatestActiveDinnerPreviews();
     }
 
     @Override
     public List<RecipeRepository.RecipePreview> findRandomDinners() {
-        return recipeRepository.findRandomDinners();
+        return recipeRepository.findSixRandomActiveDinners();
     }
 
     @Override
     public RecipeRepository.RecipePreview findRandomDinner() {
-        return recipeRepository.findRandomDinner();
+        return recipeRepository.findRandomActiveDinner();
     }
 
     @Override
@@ -160,17 +166,12 @@ public class RecipeServiceImpl implements RecipeService {
 
     @Override
     public Recipe restore(Integer id) {
-        Recipe recipe = recipeRepository.findByIdIgnoreDeleted(id)
+        Recipe recipe = recipeRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException(COULD_NOT_FIND_RECIPE_WITH_ID + id));
         recipe.setDeleted(false);
         recipe.markAsUpdated(userService.getLoggedInUsername());
         recipeRepository.save(recipe);
         return recipe;
-    }
-
-    @Override
-    public List<Recipe> findAllIgnoreDeleted() {
-        return recipeRepository.findAllIgnoreDeleted();
     }
 }
 

--- a/src/test/java/com/lstierneyltd/recipebackend/controller/RecipeRestControllerImplTest.java
+++ b/src/test/java/com/lstierneyltd/recipebackend/controller/RecipeRestControllerImplTest.java
@@ -57,10 +57,10 @@ public class RecipeRestControllerImplTest {
     @Test
     public void testGetAll() {
         // When
-        recipeRestController.getAllRecipes();
+        recipeRestController.getAllActiveRecipes();
 
         // then
-        then(recipeService).should().findAll();
+        then(recipeService).should().findAllActive();
     }
 
     @Test
@@ -69,7 +69,7 @@ public class RecipeRestControllerImplTest {
         recipeRestController.getRecipesPreviewList();
 
         // then
-        then(recipeService).should().findAllRecipePreviewBy();
+        then(recipeService).should().findAllRecipePreview();
     }
 
     @Test
@@ -163,6 +163,6 @@ public class RecipeRestControllerImplTest {
         recipeRestController.getAllRecipesIgnoreDeleted();
 
         // then
-        then(recipeService).should().findAllIgnoreDeleted();
+        then(recipeService).should().findAll();
     }
 }

--- a/src/test/java/com/lstierneyltd/recipebackend/integration/RestIntegrationTests.java
+++ b/src/test/java/com/lstierneyltd/recipebackend/integration/RestIntegrationTests.java
@@ -122,10 +122,10 @@ public class RestIntegrationTests {
     }
 
     private static void verifyRecipePreview(RecipeRepository.RecipePreview preview) {
-        assertThat(preview.getId(), is(6));
-        assertThat(preview.getName(), is("Spaghetti Bolognaise"));
-        assertThat(preview.getDescription(), is("The all time favourite"));
-        assertThat(preview.getImageFileName(), is("bolognese_test.jpg"));
+        assertThat(preview.getId(), is(2));
+        assertThat(preview.getName(), is("Spaghetti Bolognese"));
+        assertThat(preview.getDescription(), is("Everybody has their own version of this recipe; this is mine"));
+        assertThat(preview.getImageFileName(), is("bolognese.jpg"));
     }
 
     private void verifyIngredient(Ingredient ingredient1, String description, BigDecimal quantity, Unit unit) {
@@ -329,14 +329,14 @@ public class RestIntegrationTests {
 
     @Test
     @Order(29)
-    public void testGetLatestRecipe() {
+    public void testGetLatestRecipes() {
         ResponseEntity<RecipePreviewImpl[]> response = testRestTemplate.getForEntity(API_RECIPE + "/latest", RecipePreviewImpl[].class);
 
         // Good status?
         verifyStatusOk(response.getStatusCode());
 
         RecipeRepository.RecipePreview[] previews = requireNonNull(response.getBody());
-        assertThat(previews.length, is(6));
+        assertThat(previews.length, is(2));
         verifyRecipePreview(previews[0]);
     }
 


### PR DESCRIPTION
Replaced generic queries with active-specific implementations to exclude deleted recipes. Adjusted methods, tests, and controllers to consistently handle active recipes only. Also updated dependencies to the latest versions for better performance and compatibility.