### PR TITLE
MVR-310 Folders for images

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,8 +29,10 @@ jobs:
       - name: Create Directories
         run: |
           mkdir -p "/opt/recipe-website/images/1 - Moroccan Vegetable Stew with Cous Cous"
-          mkdir -p "/opt/recipe-website/images/4 - Gnocchi Bake"
           mkdir -p "/opt/recipe-website/images/2 - Spaghetti Bolognese"
+          mkdir -p "/opt/recipe-website/images/3 - Sweet Chilli Noodles"
+          mkdir -p "/opt/recipe-website/images/4 - Gnocchi Bake"
+          mkdir -p "/opt/recipe-website/images/5 - Bangers and Mash"
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,7 +13,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-    
+
 env:
   JWT_SECRET: ssshitssecret
 
@@ -26,9 +26,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Create Directory
+      - name: Create Directories
         run: |
-          mkdir -p /opt/recipe-website/images
+          mkdir -p "/opt/recipe-website/images/1 - Moroccan Vegetable Stew with Cous Cous"
+          mkdir -p "/opt/recipe-website/images/4 - Gnocchi Bake"
+          mkdir -p "/opt/recipe-website/images/2 - Spaghetti Bolognese"
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3
@@ -39,4 +41,3 @@ jobs:
 
       - name: Build with Maven
         run: mvn -B package --file pom.xml
-      

--- a/src/main/java/com/lstierneyltd/recipebackend/controller/RecipeRestController.java
+++ b/src/main/java/com/lstierneyltd/recipebackend/controller/RecipeRestController.java
@@ -1,37 +1,37 @@
 package com.lstierneyltd.recipebackend.controller;
 
-import com.lstierneyltd.recipebackend.entities.Recipe;
-import com.lstierneyltd.recipebackend.repository.RecipeRepository;
+import com.lstierneyltd.recipebackend.dto.RecipeDto;
+import com.lstierneyltd.recipebackend.dto.RecipePreviewDto;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 public interface RecipeRestController {
-    Recipe getRecipeById(Integer id);
+    RecipeDto getRecipeById(Integer id);
 
-    Recipe getRecipeByName(String name);
+    RecipeDto getRecipeByName(String name);
 
-    List<Recipe> getAllActiveRecipes();
+    List<RecipeDto> getAllActiveRecipes();
 
-    Recipe addRecipe(MultipartFile imageFile, String recipe);
+    RecipeDto addRecipe(MultipartFile imageFile, String recipe);
 
-    Recipe updateRecipe(MultipartFile imageFile, String recipe);
+    RecipeDto updateRecipe(MultipartFile imageFile, String recipe);
 
-    List<RecipeRepository.RecipePreview> getRecipesPreviewList();
+    List<RecipePreviewDto> getRecipesPreviewList();
 
-    List<Recipe> getRecipesByTags(List<String> tags);
+    List<RecipeDto> getRecipesByTags(List<String> tags);
 
-    List<RecipeRepository.RecipePreview> getLatestRecipes();
+    List<RecipePreviewDto> getLatestRecipePreviews();
 
-    List<RecipeRepository.RecipePreview> getRandomDinners();
+    List<RecipePreviewDto> getRandomDinnerPreviews();
 
-    RecipeRepository.RecipePreview getRandomDinner();
+    RecipePreviewDto getRandomDinnerPreview();
 
-    Recipe markRecipeAsCooked(Integer id);
+    RecipeDto markRecipeAsCooked(Integer id);
 
-    Recipe markRecipeAsDeleted(Integer id);
+    RecipeDto markRecipeAsDeleted(Integer id);
 
-    Recipe restore(Integer id);
+    RecipeDto restore(Integer id);
 
-    List<Recipe> getAllRecipesIgnoreDeleted();
+    List<RecipeDto> getAllRecipesIgnoreDeleted();
 }

--- a/src/main/java/com/lstierneyltd/recipebackend/controller/RecipeRestControllerImpl.java
+++ b/src/main/java/com/lstierneyltd/recipebackend/controller/RecipeRestControllerImpl.java
@@ -1,7 +1,7 @@
 package com.lstierneyltd.recipebackend.controller;
 
-import com.lstierneyltd.recipebackend.entities.Recipe;
-import com.lstierneyltd.recipebackend.repository.RecipeRepository;
+import com.lstierneyltd.recipebackend.dto.RecipeDto;
+import com.lstierneyltd.recipebackend.dto.RecipePreviewDto;
 import com.lstierneyltd.recipebackend.service.RecipeService;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -21,85 +21,85 @@ public class RecipeRestControllerImpl implements RecipeRestController {
 
     @Override
     @GetMapping("/id/{id}")
-    public Recipe getRecipeById(@PathVariable Integer id) {
+    public RecipeDto getRecipeById(@PathVariable Integer id) {
         return recipeService.findById(id);
     }
 
     @Override
     @GetMapping("/{name}")
-    public Recipe getRecipeByName(@PathVariable String name) {
+    public RecipeDto getRecipeByName(@PathVariable String name) {
         return recipeService.findByName(name);
     }
 
     @Override
     @GetMapping(params = "tagNames")
-    public List<Recipe> getRecipesByTags(@RequestParam("tagNames") List<String> tagNames) {
+    public List<RecipeDto> getRecipesByTags(@RequestParam("tagNames") List<String> tagNames) {
         return recipeService.findByTagNames(tagNames);
     }
 
     @Override
     @GetMapping("/latest")
-    public List<RecipeRepository.RecipePreview> getLatestRecipes() {
-        return recipeService.findLatest();
+    public List<RecipePreviewDto> getLatestRecipePreviews() {
+        return recipeService.findLatestPreviews();
     }
 
     @Override
     @GetMapping("/randomDinners")
-    public List<RecipeRepository.RecipePreview> getRandomDinners() {
-        return recipeService.findRandomDinners();
+    public List<RecipePreviewDto> getRandomDinnerPreviews() {
+        return recipeService.findRandomDinnersPreviews();
     }
 
     @Override
     @GetMapping("/randomDinner")
-    public RecipeRepository.RecipePreview getRandomDinner() {
-        return recipeService.findRandomDinner();
+    public RecipePreviewDto getRandomDinnerPreview() {
+        return recipeService.findRandomDinnerPreview();
     }
 
     @Override
     @PostMapping("/markascooked/{id}")
-    public Recipe markRecipeAsCooked(@PathVariable Integer id) {
+    public RecipeDto markRecipeAsCooked(@PathVariable Integer id) {
         return recipeService.markAsCooked(id);
     }
 
     @Override
     @GetMapping
-    public List<Recipe> getAllActiveRecipes() {
-        return recipeService.findAllActive();
+    public List<RecipeDto> getAllActiveRecipes() {
+        return recipeService.findAllActiveRecipes();
     }
 
     @Override
     @GetMapping("/list")
-    public List<RecipeRepository.RecipePreview> getRecipesPreviewList() {
-        return recipeService.findAllRecipePreview();
+    public List<RecipePreviewDto> getRecipesPreviewList() {
+        return recipeService.findAllActiveRecipePreview();
     }
 
     @Override
     @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
-    public Recipe addRecipe(@RequestParam(value = "imageFile") MultipartFile imageFile, @RequestParam(value = "recipe") String recipeString) {
+    public RecipeDto addRecipe(@RequestParam(value = "imageFile") MultipartFile imageFile, @RequestParam(value = "recipe") String recipeString) {
         return recipeService.addRecipe(imageFile, recipeString);
     }
 
     @Override
     @PutMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
-    public Recipe updateRecipe(@RequestParam(value = "imageFile", required = false) MultipartFile imageFile, @RequestParam(value = "recipe") String recipeString) {
+    public RecipeDto updateRecipe(@RequestParam(value = "imageFile", required = false) MultipartFile imageFile, @RequestParam(value = "recipe") String recipeString) {
         return recipeService.updateRecipe(imageFile, recipeString);
     }
 
     @Override
     @PutMapping("/markAsDeleted/{id}")
-    public Recipe markRecipeAsDeleted(@PathVariable Integer id) {
+    public RecipeDto markRecipeAsDeleted(@PathVariable Integer id) {
         return recipeService.markAsDeleted(id);
     }
 
     @Override
     @PutMapping("/restore/{id}")
-    public Recipe restore(@PathVariable Integer id) {
+    public RecipeDto restore(@PathVariable Integer id) {
         return recipeService.restore(id);
     }
 
     @Override
     @GetMapping("/listIgnoreDeleted")
-    public List<Recipe> getAllRecipesIgnoreDeleted() {
+    public List<RecipeDto> getAllRecipesIgnoreDeleted() {
         return recipeService.findAll();
     }
 }

--- a/src/main/java/com/lstierneyltd/recipebackend/dto/RecipeDto.java
+++ b/src/main/java/com/lstierneyltd/recipebackend/dto/RecipeDto.java
@@ -1,0 +1,316 @@
+package com.lstierneyltd.recipebackend.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.lstierneyltd.recipebackend.entities.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@JsonDeserialize(builder = RecipeDto.Builder.class)
+public class RecipeDto {
+    private int id;
+    private String name;
+    private String description;
+    private int cooked;
+    private LocalDateTime lastCooked;
+    private int cookingTime;
+    private String basedOn;
+    private List<MethodStep> methodSteps = new ArrayList<>();
+    private List<Ingredient> ingredients = new ArrayList<>();
+    private List<Note> notes = new ArrayList<>();
+    private Set<Tag> tags = new HashSet<>();
+    private ServedOn servedOn;
+    private boolean deleted;
+    private String imageFolderPath;
+    private List<String> imageFileNames;
+    private LocalDateTime lastUpdatedDate;
+    private LocalDateTime createdDate;
+    private String createdBy;
+    private String lastUpdatedBy;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public int getCooked() {
+        return cooked;
+    }
+
+    public void setCooked(int cooked) {
+        this.cooked = cooked;
+    }
+
+    public LocalDateTime getLastCooked() {
+        return lastCooked;
+    }
+
+    public void setLastCooked(LocalDateTime lastCooked) {
+        this.lastCooked = lastCooked;
+    }
+
+    public int getCookingTime() {
+        return cookingTime;
+    }
+
+    public void setCookingTime(int cookingTime) {
+        this.cookingTime = cookingTime;
+    }
+
+    public String getBasedOn() {
+        return basedOn;
+    }
+
+    public void setBasedOn(String basedOn) {
+        this.basedOn = basedOn;
+    }
+
+    public List<MethodStep> getMethodSteps() {
+        return methodSteps;
+    }
+
+    public void setMethodSteps(List<MethodStep> methodSteps) {
+        this.methodSteps = methodSteps;
+    }
+
+    public List<Ingredient> getIngredients() {
+        return ingredients;
+    }
+
+    public void setIngredients(List<Ingredient> ingredients) {
+        this.ingredients = ingredients;
+    }
+
+    public List<Note> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<Note> notes) {
+        this.notes = notes;
+    }
+
+    public Set<Tag> getTags() {
+        return tags;
+    }
+
+    public void setTags(Set<Tag> tags) {
+        this.tags = tags;
+    }
+
+    public ServedOn getServedOn() {
+        return servedOn;
+    }
+
+    public void setServedOn(ServedOn servedOn) {
+        this.servedOn = servedOn;
+    }
+
+    public boolean isDeleted() {
+        return deleted;
+    }
+
+    public void setDeleted(boolean deleted) {
+        this.deleted = deleted;
+    }
+
+    public String getImageFolderPath() {
+        return imageFolderPath;
+    }
+
+    public void setImageFolderPath(String imageFolderPath) {
+        this.imageFolderPath = imageFolderPath;
+    }
+
+    public List<String> getImageFileNames() {
+        return imageFileNames;
+    }
+
+    public void setImageFileNames(List<String> imageFileNames) {
+        this.imageFileNames = imageFileNames;
+    }
+
+    public LocalDateTime getLastUpdatedDate() {
+        return lastUpdatedDate;
+    }
+
+    public void setLastUpdatedDate(LocalDateTime lastUpdatedDate) {
+        this.lastUpdatedDate = lastUpdatedDate;
+    }
+
+    public LocalDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(LocalDateTime createdDate) {
+        this.createdDate = createdDate;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public String getLastUpdatedBy() {
+        return lastUpdatedBy;
+    }
+
+    public void setLastUpdatedBy(String lastUpdatedBy) {
+        this.lastUpdatedBy = lastUpdatedBy;
+    }
+
+    @Override
+    public String toString() {
+        return "RecipeDto{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", description='" + description + '\'' +
+                ", cooked=" + cooked +
+                ", lastCooked=" + lastCooked +
+                ", cookingTime=" + cookingTime +
+                ", basedOn='" + basedOn + '\'' +
+                ", methodSteps=" + methodSteps +
+                ", ingredients=" + ingredients +
+                ", notes=" + notes +
+                ", tags=" + tags +
+                ", servedOn=" + servedOn +
+                ", deleted=" + deleted +
+                ", imageFolderPath='" + imageFolderPath + '\'' +
+                ", imageFileNames=" + imageFileNames +
+                ", lastUpdatedDate=" + lastUpdatedDate +
+                ", createdDate=" + createdDate +
+                ", createdBy='" + createdBy + '\'' +
+                ", lastUpdatedBy='" + lastUpdatedBy + '\'' +
+                '}';
+    }
+
+    // Builder class
+    @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "with")
+    public static class Builder {
+        private RecipeDto instance = new RecipeDto();
+
+        public Builder withId(int id) {
+            instance.id = id;
+            return this;
+        }
+
+        public Builder withName(String name) {
+            instance.name = name;
+            return this;
+        }
+
+        public Builder withDescription(String description) {
+            instance.description = description;
+            return this;
+        }
+
+        public Builder withCooked(int cooked) {
+            instance.cooked = cooked;
+            return this;
+        }
+
+        public Builder withLastCooked(LocalDateTime lastCooked) {
+            instance.lastCooked = lastCooked;
+            return this;
+        }
+
+        public Builder withCookingTime(int cookingTime) {
+            instance.cookingTime = cookingTime;
+            return this;
+        }
+
+        public Builder withBasedOn(String basedOn) {
+            instance.basedOn = basedOn;
+            return this;
+        }
+
+        public Builder withMethodSteps(List<MethodStep> methodSteps) {
+            instance.methodSteps = methodSteps;
+            return this;
+        }
+
+        public Builder withIngredients(List<Ingredient> ingredients) {
+            instance.ingredients = ingredients;
+            return this;
+        }
+
+        public Builder withNotes(List<Note> notes) {
+            instance.notes = notes;
+            return this;
+        }
+
+        public Builder withTags(Set<Tag> tags) {
+            instance.tags = tags;
+            return this;
+        }
+
+        public Builder withServedOn(ServedOn servedOn) {
+            instance.servedOn = servedOn;
+            return this;
+        }
+
+        public Builder withDeleted(boolean del) {
+            instance.deleted = del;
+            return this;
+        }
+
+        public Builder withImageFolderPath(String path) {
+            instance.imageFolderPath = path;
+            return this;
+        }
+
+        public Builder withImageFileNames(List<String> names) {
+            instance.imageFileNames = names;
+            return this;
+        }
+
+        public Builder withCreatedDate(LocalDateTime createdDate) {
+            instance.createdDate = createdDate;
+            return this;
+        }
+
+        public Builder withLastUpdatedDate(LocalDateTime lastUpdatedDate) {
+            instance.lastUpdatedDate = lastUpdatedDate;
+            return this;
+        }
+
+        public Builder withLastUpdatedBy(String lastUpdatedBy) {
+            instance.lastUpdatedBy = lastUpdatedBy;
+            return this;
+        }
+
+        public Builder withCreatedBy(String createdBy) {
+            instance.createdBy = createdBy;
+            return this;
+        }
+
+        public RecipeDto build() {
+            return instance;
+        }
+    }
+}

--- a/src/main/java/com/lstierneyltd/recipebackend/dto/RecipePreviewDto.java
+++ b/src/main/java/com/lstierneyltd/recipebackend/dto/RecipePreviewDto.java
@@ -1,0 +1,133 @@
+package com.lstierneyltd.recipebackend.dto;
+
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@JsonDeserialize(builder = RecipePreviewDto.Builder.class)
+public class RecipePreviewDto {
+
+    private int id;
+    private String name;
+    private String description;
+    private int cooked;
+    private LocalDateTime lastCooked;
+    private String imageFolderPath;
+    private List<String> imageFileNames;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public int getCooked() {
+        return cooked;
+    }
+
+    public void setCooked(int cooked) {
+        this.cooked = cooked;
+    }
+
+    public LocalDateTime getLastCooked() {
+        return lastCooked;
+    }
+
+    public void setLastCooked(LocalDateTime lastCooked) {
+        this.lastCooked = lastCooked;
+    }
+
+    public String getImageFolderPath() {
+        return imageFolderPath;
+    }
+
+    public void setImageFolderPath(String imageFolderPath) {
+        this.imageFolderPath = imageFolderPath;
+    }
+
+    public List<String> getImageFileNames() {
+        return imageFileNames;
+    }
+
+    public void setImageFileNames(List<String> imageFileNames) {
+        this.imageFileNames = imageFileNames;
+    }
+
+    @Override
+    public String toString() {
+        return "RecipePreviewDto{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", description='" + description + '\'' +
+                ", cooked=" + cooked +
+                ", lastCooked=" + lastCooked +
+                ", imageFolderPath='" + imageFolderPath + '\'' +
+                ", imageFileNames=" + imageFileNames +
+                '}';
+    }
+
+    @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "with")
+    public static class Builder {
+        private RecipePreviewDto instance = new RecipePreviewDto();
+
+        public Builder withId(int id) {
+            instance.id = id;
+            return this;
+        }
+
+        public Builder withName(String name) {
+            instance.name = name;
+            return this;
+        }
+
+        public Builder withDescription(String description) {
+            instance.description = description;
+            return this;
+        }
+
+        public Builder withCooked(int cooked) {
+            instance.cooked = cooked;
+            return this;
+        }
+
+        public Builder withLastCooked(LocalDateTime lastCooked) {
+            instance.lastCooked = lastCooked;
+            return this;
+        }
+
+        public Builder withImageFolderPath(String path) {
+            instance.imageFolderPath = path;
+            return this;
+        }
+
+        public Builder withImageFileNames(List<String> names) {
+            instance.imageFileNames = names;
+            return this;
+        }
+
+        public RecipePreviewDto build() {
+            return instance;
+        }
+    }
+}

--- a/src/main/java/com/lstierneyltd/recipebackend/entities/Recipe.java
+++ b/src/main/java/com/lstierneyltd/recipebackend/entities/Recipe.java
@@ -20,7 +20,6 @@ public class Recipe extends Auditable implements java.io.Serializable {
     private int id;
     private String name;
     private String description;
-    private String imageFileName;
     private int cooked;
     private LocalDateTime lastCooked;
     private int cookingTime;
@@ -146,15 +145,6 @@ public class Recipe extends Auditable implements java.io.Serializable {
         this.tags = tags;
     }
 
-    @Column(name = "image_filename", length = 100)
-    public String getImageFileName() {
-        return this.imageFileName;
-    }
-
-    public void setImageFileName(String imageFileName) {
-        this.imageFileName = imageFileName;
-    }
-
     @Column(name = "based_on", length = 250)
     public String getBasedOn() {
         return this.basedOn;
@@ -181,6 +171,15 @@ public class Recipe extends Auditable implements java.io.Serializable {
 
     public void setDeleted(boolean deleted) {
         this.deleted = deleted;
+    }
+
+    @Transient
+    public String getImageFolderName() {
+        if (id > 0) {
+            return id + " " + "- " + name;
+        } else {
+            return "No ID available yet";
+        }
     }
 
     @Generated

--- a/src/main/java/com/lstierneyltd/recipebackend/entities/RecipePreviewImpl.java
+++ b/src/main/java/com/lstierneyltd/recipebackend/entities/RecipePreviewImpl.java
@@ -9,9 +9,7 @@ public class RecipePreviewImpl implements RecipeRepository.RecipePreview {
     private int id;
     private String name;
     private String description;
-    private String imageFileName;
     private int cooked;
-
     private LocalDateTime lastCooked;
 
     @Override
@@ -42,15 +40,6 @@ public class RecipePreviewImpl implements RecipeRepository.RecipePreview {
     }
 
     @Override
-    public String getImageFileName() {
-        return imageFileName;
-    }
-
-    public void setImageFileName(String imageFileName) {
-        this.imageFileName = imageFileName;
-    }
-
-    @Override
     public int getCooked() {
         return cooked;
     }
@@ -75,7 +64,6 @@ public class RecipePreviewImpl implements RecipeRepository.RecipePreview {
                 "id=" + id +
                 ", name='" + name + '\'' +
                 ", description='" + description + '\'' +
-                ", imageFileName='" + imageFileName + '\'' +
                 ", cooked='" + cooked + '\'' +
                 ", lastCooked='" + lastCooked + '\'' +
                 '}';

--- a/src/main/java/com/lstierneyltd/recipebackend/repository/RecipeRepository.java
+++ b/src/main/java/com/lstierneyltd/recipebackend/repository/RecipeRepository.java
@@ -22,7 +22,7 @@ public interface RecipeRepository extends JpaRepository<Recipe, Integer> {
     List<RecipePreview> findSixRandomActiveDinners();
 
     @Query("SELECT r FROM Recipe r JOIN r.tags t WHERE t.name = 'dinner' AND r.deleted = false ORDER BY RAND() LIMIT 1")
-    RecipePreview findRandomActiveDinner();
+    RecipePreview findRandomActiveDinnerPreview();
 
     @Query("SELECT r FROM Recipe r JOIN r.tags t WHERE t.name = 'dinner' AND r.deleted = false ORDER BY r.id desc LIMIT 6")
     List<RecipePreview> findSixLatestActiveDinnerPreviews();
@@ -41,8 +41,6 @@ public interface RecipeRepository extends JpaRepository<Recipe, Integer> {
         int getId();
 
         String getName();
-
-        String getImageFileName();
 
         String getDescription();
 

--- a/src/main/java/com/lstierneyltd/recipebackend/service/DtoService.java
+++ b/src/main/java/com/lstierneyltd/recipebackend/service/DtoService.java
@@ -1,0 +1,18 @@
+package com.lstierneyltd.recipebackend.service;
+
+import com.lstierneyltd.recipebackend.dto.RecipeDto;
+import com.lstierneyltd.recipebackend.dto.RecipePreviewDto;
+import com.lstierneyltd.recipebackend.entities.Recipe;
+import com.lstierneyltd.recipebackend.repository.RecipeRepository;
+
+import java.util.List;
+
+public interface DtoService {
+    RecipeDto recipeToRecipeDto(Recipe recipe);
+
+    List<RecipeDto> recipesToRecipeDtos(List<Recipe> recipes);
+
+    RecipePreviewDto recipePreviewToRecipePreviewDto(RecipeRepository.RecipePreview recipePreview);
+
+    List<RecipePreviewDto> recipePreviewsToRecipePreviewDtos(List<RecipeRepository.RecipePreview> recipePreviews);
+}

--- a/src/main/java/com/lstierneyltd/recipebackend/service/DtoServiceImpl.java
+++ b/src/main/java/com/lstierneyltd/recipebackend/service/DtoServiceImpl.java
@@ -1,0 +1,80 @@
+package com.lstierneyltd.recipebackend.service;
+
+import com.lstierneyltd.recipebackend.dto.RecipeDto;
+import com.lstierneyltd.recipebackend.dto.RecipePreviewDto;
+import com.lstierneyltd.recipebackend.entities.Recipe;
+import com.lstierneyltd.recipebackend.repository.RecipeRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class DtoServiceImpl implements DtoService {
+    private final FileService fileService;
+    @Value("${file.upload.directory}")
+    private String fileUploadDirectory;
+
+    public DtoServiceImpl(FileService fileService) {
+        this.fileService = fileService;
+    }
+
+    @Override
+    public RecipeDto recipeToRecipeDto(Recipe recipe) {
+        String imageFolderPath = fileUploadDirectory + "/images/" + recipe.getImageFolderName() + "/";
+        List<String> imageFileNames = fileService.getFilesInDirectory(imageFolderPath);
+
+        return new RecipeDto.Builder()
+                .withId(recipe.getId())
+                .withName(recipe.getName())
+                .withDescription(recipe.getDescription())
+                .withCooked(recipe.getCooked())
+                .withLastCooked(recipe.getLastCooked())
+                .withCookingTime(recipe.getCookingTime())
+                .withBasedOn(recipe.getBasedOn())
+                .withMethodSteps(recipe.getMethodSteps())
+                .withIngredients(recipe.getIngredients())
+                .withNotes(recipe.getNotes())
+                .withTags(recipe.getTags())
+                .withServedOn(recipe.getServedOn())
+                .withDeleted(recipe.isDeleted())
+                .withImageFolderPath("/images/" + recipe.getImageFolderName() + "/")
+                .withImageFileNames(imageFileNames)
+                .withCreatedDate(recipe.getCreatedDate())
+                .withCreatedBy(recipe.getCreatedBy())
+                .withLastUpdatedDate(recipe.getLastUpdatedDate())
+                .withLastUpdatedBy(recipe.getLastUpdatedBy())
+                .build();
+    }
+
+    @Override
+    public List<RecipeDto> recipesToRecipeDtos(List<Recipe> recipes) {
+        return recipes.stream()
+                .map(this::recipeToRecipeDto)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public RecipePreviewDto recipePreviewToRecipePreviewDto(RecipeRepository.RecipePreview recipePreview) {
+        String imageFolderName = recipePreview.getId() + " " + "- " + recipePreview.getName(); // TODO - this is here AND in Recipe
+        String imageFolderPath = fileUploadDirectory + "images/" + imageFolderName + "/";
+
+        return new RecipePreviewDto.Builder()
+                .withId(recipePreview.getId())
+                .withCooked(recipePreview.getCooked())
+                .withDescription(recipePreview.getDescription())
+                .withName(recipePreview.getName())
+                .withLastCooked(recipePreview.getLastCooked())
+                .withImageFolderPath("/images/" + imageFolderName + "/")
+                .withImageFileNames(fileService.getFilesInDirectory(imageFolderPath))
+                .build();
+    }
+
+    @Override
+    public List<RecipePreviewDto> recipePreviewsToRecipePreviewDtos(List<RecipeRepository.RecipePreview> recipePreviews) {
+        return recipePreviews.stream()
+                .map(this::recipePreviewToRecipePreviewDto)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/lstierneyltd/recipebackend/service/FileService.java
+++ b/src/main/java/com/lstierneyltd/recipebackend/service/FileService.java
@@ -1,7 +1,14 @@
 package com.lstierneyltd.recipebackend.service;
 
+import com.lstierneyltd.recipebackend.entities.Recipe;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 public interface FileService {
-    void saveMultiPartFile(MultipartFile multipartFile);
+    void createImageFolder(Recipe recipe);
+
+    void addImageToRecipe(MultipartFile imageFile, Recipe recipe);
+
+    List<String> getFilesInDirectory(String imageFolderPath);
 }

--- a/src/main/java/com/lstierneyltd/recipebackend/service/FileServiceImpl.java
+++ b/src/main/java/com/lstierneyltd/recipebackend/service/FileServiceImpl.java
@@ -1,29 +1,74 @@
 package com.lstierneyltd.recipebackend.service;
 
+import com.lstierneyltd.recipebackend.entities.Recipe;
 import com.lstierneyltd.recipebackend.exception.RecipeBackendException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 public class FileServiceImpl implements FileService {
+    private final Logger logger = LoggerFactory.getLogger(FileServiceImpl.class);
+
     @Value("${file.upload.directory}")
     private String fileUploadDirectory;
 
-    // TODO deal with "images/"
     @Override
-    public void saveMultiPartFile(final MultipartFile multipartFile) {
+    public void createImageFolder(Recipe recipe) {
+        Path path = Paths.get(getRecipeFolderPath(recipe));
         try {
-            byte[] bytes = multipartFile.getBytes();
-            Path path = Paths.get(fileUploadDirectory + "images/" + multipartFile.getOriginalFilename());
+            if (!Files.exists(path)) {
+                Files.createDirectories(path);
+                System.out.println("Directory " + path + " created");
+            } else {
+                System.out.println("Directory " + path + " already exists, skipping creation");
+            }
+        } catch (Exception e) {
+            throw new RecipeBackendException(e.getMessage());
+        }
+    }
+
+    @Override
+    public void addImageToRecipe(MultipartFile imageFile, Recipe recipe) {
+        try {
+            byte[] bytes = imageFile.getBytes();
+            Path path = Paths.get(getRecipeFolderPath(recipe) + "/" + imageFile.getOriginalFilename());
             Files.write(path, bytes);
         } catch (Exception e) {
             e.printStackTrace();
             throw new RecipeBackendException("Could not save uploaded file: " + e.getMessage());
         }
+    }
+
+    @Override
+    public List<String> getFilesInDirectory(String dirPath) {
+        List<String> fileNames = new ArrayList<>();
+        Path path = Paths.get(dirPath);
+
+        try (DirectoryStream<Path> paths = Files.newDirectoryStream(path)) {
+            for (Path p : paths) {
+                fileNames.add(p.getFileName().toString());
+            }
+        } catch (IOException e) {
+            logger.error("Could not read files in dir: " + dirPath);
+            // i think throwing an exception here is reasonable
+            // as we expect the folder, and at least one image, to exist
+            throw new RecipeBackendException(e.getMessage());
+        }
+        return fileNames;
+    }
+
+    private String getRecipeFolderPath(Recipe recipe) {
+        return fileUploadDirectory + "/images/" + recipe.getImageFolderName();
     }
 }

--- a/src/main/java/com/lstierneyltd/recipebackend/service/RecipeService.java
+++ b/src/main/java/com/lstierneyltd/recipebackend/service/RecipeService.java
@@ -1,38 +1,38 @@
 package com.lstierneyltd.recipebackend.service;
 
-import com.lstierneyltd.recipebackend.entities.Recipe;
-import com.lstierneyltd.recipebackend.repository.RecipeRepository;
+import com.lstierneyltd.recipebackend.dto.RecipeDto;
+import com.lstierneyltd.recipebackend.dto.RecipePreviewDto;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 public interface RecipeService {
-    Recipe addRecipe(MultipartFile imageFile, String recipeString);
+    RecipeDto addRecipe(MultipartFile imageFile, String recipeString);
 
-    Recipe updateRecipe(MultipartFile imageFile, String recipeString);
+    RecipeDto updateRecipe(MultipartFile imageFile, String recipeString);
 
-    Recipe findById(int id);
+    RecipeDto findById(int id);
 
-    Recipe findByName(String name);
+    RecipeDto findByName(String name);
 
-    List<Recipe> findByTagNames(List<String> tagNames);
+    List<RecipeDto> findByTagNames(List<String> tagNames);
 
-    List<Recipe> findAllActive();
+    List<RecipeDto> findAllActiveRecipes();
 
-    List<Recipe> findAll();
+    List<RecipeDto> findAll();
 
-    List<RecipeRepository.RecipePreview> findAllRecipePreview();
+    List<RecipePreviewDto> findAllActiveRecipePreview();
 
-    List<RecipeRepository.RecipePreview> findLatest();
+    List<RecipePreviewDto> findLatestPreviews();
 
-    List<RecipeRepository.RecipePreview> findRandomDinners();
+    List<RecipePreviewDto> findRandomDinnersPreviews();
 
-    RecipeRepository.RecipePreview findRandomDinner();
+    RecipePreviewDto findRandomDinnerPreview();
 
-    Recipe markAsCooked(Integer id);
+    RecipeDto markAsCooked(Integer id);
 
-    Recipe markAsDeleted(Integer id);
+    RecipeDto markAsDeleted(Integer id);
 
-    Recipe restore(Integer id);
+    RecipeDto restore(Integer id);
 }
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -63,20 +63,19 @@ VALUES (17,'ingredient','An input ingredient to a recipe');
 INSERT INTO recipe
 VALUES (1, 'Moroccan Vegetable Stew with Cous Cous', 'Mildly spicy, slowish cooked veg with cous cous.', 60,
         'https://www.food.com/recipe/moroccan-vegetable-stew-with-couscous-274742',
-        NULL, 0, NULL,
-        'Cous_cous.jpg', NOW(), NOW(), 'lawrence', 'lawrence', 0);
+        NULL, 0, NULL, NOW(), NOW(), 'lawrence', 'lawrence', 0);
 INSERT INTO recipe
 VALUES (2, 'Spaghetti Bolognese', 'Everybody has their own version of this recipe; this is mine', 30, NULL,
-        NULL, 1, NULL, 'bolognese.jpg', NULL, NULL, NULL, NULL, 0);
+        NULL, 1, NULL, NULL, NULL, NULL, NULL, 0);
 INSERT INTO recipe
 VALUES (3, 'Sweet Chilli Noodles', 'A change from the usual stir fry, this recipe has a smoother sweeter flavour.', 45,
-        NULL, NULL, 2, NULL, 'sweet-chilli-noodles.jpg', NULL, NULL, NULL, NULL, 0);
+        NULL, NULL, 2, NULL, NULL, NULL, NULL, NULL, 0);
 INSERT INTO recipe
 VALUES (4, 'Gnocchi Bake', 'A cheesy, tomatoey, slice of heaven. Not for everyday consumption!', 90, NULL,
-        NULL, 3, NULL, 'gnocchi.jpg', NULL, NULL, NULL, NULL, 0);
+        NULL, 3, NULL, NULL, NULL, NULL, NULL, 0);
 INSERT INTO recipe
 VALUES (5, 'Bangers and Mash', 'A stone cold classic with the added twist of some spring onion in the mash', 45, NULL,
-        NULL, 4, NULL, 'Bangers and Mash.jpg', NULL, NULL, NULL, NULL, 0);
+        NULL, 4, NULL, NULL, NULL, NULL, NULL, 0);
 
 INSERT INTO ingredient
 VALUES (1, 'Coriander Seeds', 0.50, 1, 1, 1);

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -17,7 +17,6 @@ create table recipe
     served_on_id   int,
     cooked         int default 0 not null,
     last_cooked    timestamp,
-    image_filename varchar(100),
     created_date      timestamp,
     last_updated_date timestamp,
     created_by        varchar(100),

--- a/src/test/java/com/lstierneyltd/recipebackend/controller/RecipeRestControllerImplTest.java
+++ b/src/test/java/com/lstierneyltd/recipebackend/controller/RecipeRestControllerImplTest.java
@@ -60,7 +60,7 @@ public class RecipeRestControllerImplTest {
         recipeRestController.getAllActiveRecipes();
 
         // then
-        then(recipeService).should().findAllActive();
+        then(recipeService).should().findAllActiveRecipes();
     }
 
     @Test
@@ -69,7 +69,7 @@ public class RecipeRestControllerImplTest {
         recipeRestController.getRecipesPreviewList();
 
         // then
-        then(recipeService).should().findAllRecipePreview();
+        then(recipeService).should().findAllActiveRecipePreview();
     }
 
     @Test
@@ -106,28 +106,28 @@ public class RecipeRestControllerImplTest {
     @Test
     public void testGetLatestRecipe() {
         // when
-        recipeRestController.getLatestRecipes();
+        recipeRestController.getLatestRecipePreviews();
 
         // then
-        then(recipeService).should().findLatest();
+        then(recipeService).should().findLatestPreviews();
     }
 
     @Test
     public void testGetRandomDinners() {
         // when
-        recipeRestController.getRandomDinners();
+        recipeRestController.getRandomDinnerPreviews();
 
         // then
-        then(recipeService).should().findRandomDinners();
+        then(recipeService).should().findRandomDinnersPreviews();
     }
 
     @Test
     public void testGetRandomDinner() {
         // when
-        recipeRestController.getRandomDinner();
+        recipeRestController.getRandomDinnerPreview();
 
         // then
-        then(recipeService).should().findRandomDinner();
+        then(recipeService).should().findRandomDinnerPreview();
     }
 
     @Test

--- a/src/test/java/com/lstierneyltd/recipebackend/dto/RecipeDtoTest.java
+++ b/src/test/java/com/lstierneyltd/recipebackend/dto/RecipeDtoTest.java
@@ -1,0 +1,44 @@
+package com.lstierneyltd.recipebackend.dto;
+
+import com.lstierneyltd.recipebackend.entities.Recipe;
+import com.lstierneyltd.recipebackend.utils.TestStubs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RecipeDtoTest {
+    private final Recipe recipe = TestStubs.getRecipe();
+    private RecipeDto recipeDto;
+
+    @BeforeEach
+    void before() {
+
+        RecipeDto.Builder builder = new RecipeDto.Builder();
+        recipeDto = builder
+                .withId(recipe.getId())
+                .withName(recipe.getName())
+                .withDescription(recipe.getDescription())
+                .withCooked(recipe.getCooked())
+                .withLastCooked(recipe.getLastCooked())
+                .withCookingTime(recipe.getCookingTime())
+                .withBasedOn(recipe.getBasedOn())
+                .withMethodSteps(recipe.getMethodSteps())
+                .withIngredients(recipe.getIngredients())
+                .withNotes(recipe.getNotes())
+                .withTags(recipe.getTags())
+                .withServedOn(recipe.getServedOn())
+                .withDeleted(recipe.isDeleted())
+                .withImageFolderPath("images/")
+                .withImageFileNames(Arrays.asList("image1.jpg", "image2.jpg"))
+                .build();
+    }
+
+    @Test
+    public void testIdSet() {
+        assertEquals(recipeDto.getId(), recipe.getId());
+    }
+
+}

--- a/src/test/java/com/lstierneyltd/recipebackend/entities/RecipePreviewImplTest.java
+++ b/src/test/java/com/lstierneyltd/recipebackend/entities/RecipePreviewImplTest.java
@@ -34,12 +34,6 @@ public class RecipePreviewImplTest {
     }
 
     @Test
-    public void testSetGetImageFileName() {
-        preview.setImageFileName(RECIPE_1_IMAGE_FILENAME);
-        assertThat(preview.getImageFileName(), equalTo(RECIPE_1_IMAGE_FILENAME));
-    }
-
-    @Test
     public void testSetGetCooked() {
         preview.setCooked(COOKED);
         assertThat(preview.getCooked(), equalTo(COOKED));

--- a/src/test/java/com/lstierneyltd/recipebackend/entities/RecipeTest.java
+++ b/src/test/java/com/lstierneyltd/recipebackend/entities/RecipeTest.java
@@ -48,12 +48,6 @@ public class RecipeTest {
     }
 
     @Test
-    public void testGetSetImageFileName() {
-        recipe.setImageFileName(RECIPE_1_IMAGE_FILENAME);
-        assertThat(recipe.getImageFileName(), equalTo(RECIPE_1_IMAGE_FILENAME));
-    }
-
-    @Test
     public void testGetSetBasedOn() {
         recipe.setBasedOn(BASED_ON);
         assertThat(recipe.getBasedOn(), equalTo(BASED_ON));

--- a/src/test/java/com/lstierneyltd/recipebackend/integration/RestIntegrationTests.java
+++ b/src/test/java/com/lstierneyltd/recipebackend/integration/RestIntegrationTests.java
@@ -1,6 +1,8 @@
 package com.lstierneyltd.recipebackend.integration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lstierneyltd.recipebackend.dto.RecipeDto;
+import com.lstierneyltd.recipebackend.dto.RecipePreviewDto;
 import com.lstierneyltd.recipebackend.entities.*;
 import com.lstierneyltd.recipebackend.repository.RecipeRepository;
 import com.lstierneyltd.recipebackend.utils.FileUtils;
@@ -93,19 +95,25 @@ public class RestIntegrationTests {
         assertThat(unit.getAbbreviation(), equalTo("lb"));
     }
 
+    private static void verifyRecipePreviewDto(RecipePreviewDto recipePreviewDto) {
+        assertThat(recipePreviewDto.getId(), is(2));
+        assertThat(recipePreviewDto.getName(), is("Spaghetti Bolognese"));
+        assertThat(recipePreviewDto.getDescription(), is("Everybody has their own version of this recipe; this is mine"));
+    }
+
     @Test
     @Order(3)
     public void testPostRecipe() throws Exception {
-        ResponseEntity<Recipe> response = postRecipe("json/sample_post.json");
+        ResponseEntity<RecipeDto> response = postRecipe("json/sample_post.json");
 
         // Good status?
         verifyStatusOk(response.getStatusCode());
 
         // Good recipe?
-        verifyRecipe(requireNonNull(response.getBody()));
+        verifyRecipeDto(requireNonNull(response.getBody()));
     }
 
-    private ResponseEntity<Recipe> postRecipe(String pathToRecipeJson) throws IOException {
+    private ResponseEntity<RecipeDto> postRecipe(String pathToRecipeJson) throws IOException {
         String json = FileUtils.getFileAsString(pathToRecipeJson);
         ClassPathResource classPathResource = new ClassPathResource("/images/bolognese_test.jpg");
 
@@ -118,14 +126,7 @@ public class RestIntegrationTests {
 
         HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
 
-        return testRestTemplate.postForEntity(API_RECIPE, requestEntity, Recipe.class);
-    }
-
-    private static void verifyRecipePreview(RecipeRepository.RecipePreview preview) {
-        assertThat(preview.getId(), is(2));
-        assertThat(preview.getName(), is("Spaghetti Bolognese"));
-        assertThat(preview.getDescription(), is("Everybody has their own version of this recipe; this is mine"));
-        assertThat(preview.getImageFileName(), is("bolognese.jpg"));
+        return testRestTemplate.postForEntity(API_RECIPE, requestEntity, RecipeDto.class);
     }
 
     private void verifyIngredient(Ingredient ingredient1, String description, BigDecimal quantity, Unit unit) {
@@ -151,63 +152,63 @@ public class RestIntegrationTests {
         assertThat(note.getDescription(), equalTo(description));
     }
 
-    private void verifyRecipe(final Recipe recipe) {
-        logger.info("Verifying Recipe: " + recipe);
+    private void verifyRecipeDto(final RecipeDto recipeDto) {
+        logger.info("Verifying RecipeDto: " + recipeDto);
         // The recipe
-        assertThat(recipe.getId(), is(6));
-        assertThat(recipe.getName(), equalTo("Spaghetti Bolognaise"));
-        assertThat(recipe.getDescription(), equalTo("The all time favourite"));
-        assertThat(recipe.getCookingTime(), equalTo(30));
-        assertThat(recipe.getBasedOn(), equalTo("This recipe was based on this one"));
+        assertThat(recipeDto.getId(), is(6));
+        assertThat(recipeDto.getName(), equalTo("Spaghetti Bolognaise"));
+        assertThat(recipeDto.getDescription(), equalTo("The all time favourite"));
+        assertThat(recipeDto.getCookingTime(), equalTo(30));
+        assertThat(recipeDto.getBasedOn(), equalTo("This recipe was based on this one"));
 
 
         // Ingredients
-        assertThat(recipe.getIngredients().size(), equalTo(3));
-        verifyIngredient(recipe.getIngredients().get(0), "Chopped Tomatoes", BigDecimal.valueOf(1.00), new Unit(8, "400g can", "can"));
-        verifyIngredient(recipe.getIngredients().get(1), "Onion (small)", BigDecimal.valueOf(0.50), null);
-        verifyIngredient(recipe.getIngredients().get(2), "Cloves of Garlic", BigDecimal.valueOf(2.00), null);
+        assertThat(recipeDto.getIngredients().size(), equalTo(3));
+        verifyIngredient(recipeDto.getIngredients().get(0), "Chopped Tomatoes", BigDecimal.valueOf(1.00), new Unit(8, "400g can", "can"));
+        verifyIngredient(recipeDto.getIngredients().get(1), "Onion (small)", BigDecimal.valueOf(0.50), null);
+        verifyIngredient(recipeDto.getIngredients().get(2), "Cloves of Garlic", BigDecimal.valueOf(2.00), null);
 
         // Method steps
-        assertThat(recipe.getMethodSteps().size(), equalTo(2));
-        verifyMethodStep(recipe.getMethodSteps().get(0), 1, "Finely chop the onion and garlic");
-        verifyMethodStep(recipe.getMethodSteps().get(1), 2, "Add to small pot with a little olive oil");
+        assertThat(recipeDto.getMethodSteps().size(), equalTo(2));
+        verifyMethodStep(recipeDto.getMethodSteps().get(0), 1, "Finely chop the onion and garlic");
+        verifyMethodStep(recipeDto.getMethodSteps().get(1), 2, "Add to small pot with a little olive oil");
 
         // Tags
-        assertThat(recipe.getTags().size(), equalTo(2));
-        verifyTag("old-school", "Just like wot you remember", recipe.getTags().toArray(new Tag[0]));
-        verifyTag("one-pot", "Gotta keep that washing down", recipe.getTags().toArray(new Tag[0]));
+        assertThat(recipeDto.getTags().size(), equalTo(2));
+        verifyTag("old-school", "Just like wot you remember", recipeDto.getTags().toArray(new Tag[0]));
+        verifyTag("one-pot", "Gotta keep that washing down", recipeDto.getTags().toArray(new Tag[0]));
 
         // Notes
-        assertThat(recipe.getNotes().size(), equalTo(2));
-        verifyNote(recipe.getNotes().get(0), 1, "This is the first note");
-        verifyNote(recipe.getNotes().get(1), 2, "This is the second note");
+        assertThat(recipeDto.getNotes().size(), equalTo(2));
+        verifyNote(recipeDto.getNotes().get(0), 1, "This is the first note");
+        verifyNote(recipeDto.getNotes().get(1), 2, "This is the second note");
 
         // ServedOn
-        assertThat(recipe.getServedOn().isHeated(), is(true));
-        assertThat(recipe.getServedOn().getCrockery().getDescription(), is("White Plates"));
+        assertThat(recipeDto.getServedOn().isHeated(), is(true));
+        assertThat(recipeDto.getServedOn().getCrockery().getDescription(), is("White Plates"));
 
         // Cooked
-        assertThat(recipe.getCooked(), is(2));
+        assertThat(recipeDto.getCooked(), is(2));
 
         // CreatedDate
-        assertTrue(areWithinSeconds(recipe.getCreatedDate(), LocalDateTime.now(), 10));
-        assertThat(recipe.getCreatedBy(), is("anonymousUser")); // because we are not logged in
+        assertTrue(areWithinSeconds(recipeDto.getCreatedDate(), LocalDateTime.now(), 10));
+        assertThat(recipeDto.getCreatedBy(), is("anonymousUser")); // because we are not logged in
     }
 
     @Test
     @Order(4)
     public void testGetAllRecipes() {
-        ResponseEntity<Recipe[]> response = testRestTemplate.getForEntity(API_RECIPE, Recipe[].class);
+        ResponseEntity<RecipeDto[]> response = testRestTemplate.getForEntity(API_RECIPE, RecipeDto[].class);
 
         // Good status?
         verifyStatusOk(response.getStatusCode());
 
         // Recipe
-        final Recipe[] recipes = requireNonNull(response.getBody());
-        assertThat(recipes.length, equalTo(6));
+        final RecipeDto[] recipeDtos = requireNonNull(response.getBody());
+        assertThat(recipeDtos.length, equalTo(6));
 
         // Just one just now
-        verifyRecipe(recipes[5]);
+        verifyRecipeDto(recipeDtos[5]);
     }
 
     @Test
@@ -225,12 +226,12 @@ public class RestIntegrationTests {
     @Test
     @Order(5)
     public void testGetRecipeById() {
-        ResponseEntity<Recipe> response = testRestTemplate.getForEntity(API_RECIPE + "/id/6", Recipe.class);
+        ResponseEntity<RecipeDto> response = testRestTemplate.getForEntity(API_RECIPE + "/id/6", RecipeDto.class);
 
         // Good status?
         verifyStatusOk(response.getStatusCode());
 
-        verifyRecipe(requireNonNull(response.getBody()));
+        verifyRecipeDto(requireNonNull(response.getBody()));
     }
 
     @Test
@@ -290,29 +291,29 @@ public class RestIntegrationTests {
     @Test
     @Order(25)
     public void testGetRecipesByTagName() {
-        ResponseEntity<Recipe[]> response = testRestTemplate.getForEntity(API_RECIPE + "?tagNames=one-pot", Recipe[].class);
+        ResponseEntity<RecipeDto[]> response = testRestTemplate.getForEntity(API_RECIPE + "?tagNames=one-pot", RecipeDto[].class);
 
         // Good status?
         verifyStatusOk(response.getStatusCode());
 
         // Recipes
-        final Recipe[] recipes = requireNonNull(response.getBody());
-        assertThat(recipes.length, equalTo(2));
+        final RecipeDto[] recipeDtos = requireNonNull(response.getBody());
+        assertThat(recipeDtos.length, equalTo(2));
 
-        verifyRecipe(recipes[1]);
+        verifyRecipeDto(recipeDtos[1]);
     }
 
     @Test
     @Order(26)
     public void testGetRecipesByTagNames_1tags() {
-        ResponseEntity<Recipe[]> response = testRestTemplate.getForEntity(API_RECIPE + "?tagNames=new-name", Recipe[].class);
+        ResponseEntity<RecipeDto[]> response = testRestTemplate.getForEntity(API_RECIPE + "?tagNames=new-name", RecipeDto[].class);
 
         // Good status?
         verifyStatusOk(response.getStatusCode());
 
         // Recipes
-        final Recipe[] recipes = requireNonNull(response.getBody());
-        assertThat(recipes.length, equalTo(3));
+        final RecipeDto[] recipeDtos = requireNonNull(response.getBody());
+        assertThat(recipeDtos.length, equalTo(3));
     }
     @Test
     @Order(27)
@@ -330,26 +331,26 @@ public class RestIntegrationTests {
     @Test
     @Order(29)
     public void testGetLatestRecipes() {
-        ResponseEntity<RecipePreviewImpl[]> response = testRestTemplate.getForEntity(API_RECIPE + "/latest", RecipePreviewImpl[].class);
+        ResponseEntity<RecipePreviewDto[]> response = testRestTemplate.getForEntity(API_RECIPE + "/latest", RecipePreviewDto[].class);
 
         // Good status?
         verifyStatusOk(response.getStatusCode());
 
-        RecipeRepository.RecipePreview[] previews = requireNonNull(response.getBody());
-        assertThat(previews.length, is(2));
-        verifyRecipePreview(previews[0]);
+        RecipePreviewDto[] recipePreviewDtos = requireNonNull(response.getBody());
+        assertThat(recipePreviewDtos.length, is(2));
+        verifyRecipePreviewDto(recipePreviewDtos[0]);
     }
 
     @Test
     @Order(30)
     public void testGetRecipeByName() {
-        ResponseEntity<Recipe> response = testRestTemplate.getForEntity(API_RECIPE + "/spaghetti-bolognaise", Recipe.class);
+        ResponseEntity<RecipeDto> response = testRestTemplate.getForEntity(API_RECIPE + "/spaghetti-bolognaise", RecipeDto.class);
 
         // Good status?
         verifyStatusOk(response.getStatusCode());
 
-        Recipe recipe = requireNonNull(response.getBody());
-        verifyRecipe(recipe);
+        RecipeDto recipeDto = requireNonNull(response.getBody());
+        verifyRecipeDto(recipeDto);
     }
 
     @Test
@@ -378,14 +379,14 @@ public class RestIntegrationTests {
     @Test
     @Order(50)
     void testMarkRecipeAsCooked() {
-        final ResponseEntity<Recipe> response = testRestTemplate.postForEntity(API_RECIPE + "/markascooked/6", null, Recipe.class);
+        final ResponseEntity<RecipeDto> response = testRestTemplate.postForEntity(API_RECIPE + "/markascooked/6", null, RecipeDto.class);
         LocalDateTime now = LocalDateTime.now();
 
         verifyStatusOk(response.getStatusCode());
-        final Recipe recipe = requireNonNull(response.getBody());
+        final RecipeDto recipeDto = requireNonNull(response.getBody());
 
-        long secondsBetween = ChronoUnit.SECONDS.between(now, recipe.getLastCooked());
-        assertThat(recipe.getCooked(), is(3));
+        long secondsBetween = ChronoUnit.SECONDS.between(now, recipeDto.getLastCooked());
+        assertThat(recipeDto.getCooked(), is(3));
         assertThat(secondsBetween, lessThanOrEqualTo(5L));
     }
 
@@ -405,17 +406,15 @@ public class RestIntegrationTests {
     @Test
     @Order(200)
     public void testUpdateRecipe() throws Exception {
-        ResponseEntity<Recipe> response = postRecipe("json/chana_masala.json");
+        ResponseEntity<RecipeDto> response = postRecipe("json/chana_masala.json");
         verifyStatusOk(response.getStatusCode());
 
         // So at this point we have inserted the nice, new, shiny recipe.
         // Lets update the recipe, PUT it and test the response
-        Recipe recipe = requireNonNull(response.getBody());
-        recipe.setName("This is modified recipe name");
-        recipe.setDescription("This is the modified description");
-        recipe.setCookingTime(123);
-        recipe.setImageFileName("new_image.jpg");
-        recipe.setBasedOn("http://www.random.com");
+        RecipeDto recipeDto = requireNonNull(response.getBody());
+        recipeDto.setDescription("This is the modified description");
+        recipeDto.setCookingTime(123);
+        recipeDto.setBasedOn("http://www.random.com");
 
         ServedOn servedOn = new ServedOn();
         Crockery crockery = new Crockery();
@@ -423,12 +422,12 @@ public class RestIntegrationTests {
         crockery.setDescription("White Plates");
         servedOn.setHeated(false);
         servedOn.setCrockery(crockery);
-        recipe.setServedOn(servedOn);
+        recipeDto.setServedOn(servedOn);
 
         // Do the collections
 
         // Notes
-        List<Note> notes = recipe.getNotes();
+        List<Note> notes = recipeDto.getNotes();
         // Delete an existing Note
         notes.remove(1);
         // Modify an existing Note
@@ -439,10 +438,10 @@ public class RestIntegrationTests {
         newNote.setDescription("New Note desc");
         newNote.setOrdering(420);
         notes.add(newNote);
-        recipe.setNotes(notes);
+        recipeDto.setNotes(notes);
 
         // MethodSteps - starts with 8 MethodSteps
-        List<MethodStep> methodSteps = recipe.getMethodSteps();
+        List<MethodStep> methodSteps = recipeDto.getMethodSteps();
         methodSteps.remove(0);
         methodSteps.remove(0);
         methodSteps.get(0).setDescription("Method Step modified desc");
@@ -451,10 +450,10 @@ public class RestIntegrationTests {
         methodStep.setDescription("Desc for new MethodStep");
         methodStep.setOrdering(321);
         methodSteps.add(methodStep);
-        recipe.setMethodSteps(methodSteps);
+        recipeDto.setMethodSteps(methodSteps);
 
         // Ingredients - starts with 18 Ingredients
-        List<Ingredient> ingredients = recipe.getIngredients();
+        List<Ingredient> ingredients = recipeDto.getIngredients();
         ingredients.remove(0); // delete the first
         ingredients.remove(ingredients.size() - 1); // delete the last
         ingredients.remove(7); // delete one from in the middle
@@ -473,58 +472,56 @@ public class RestIntegrationTests {
         ingredient.setUnit(unit);
 
         ingredients.add(ingredient);
-        recipe.setIngredients(ingredients);
+        recipeDto.setIngredients(ingredients);
 
 
         // Tags
-        Set<Tag> tags = recipe.getTags();
+        Set<Tag> tags = recipeDto.getTags();
         Tag tag = new Tag();
         tag.setId(4);
         tag.setName("old-school");
         tag.setDescription("Just like wot you remember");
         tags.add(tag);
-        recipe.setTags(tags);
+        recipeDto.setTags(tags);
 
         final HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.MULTIPART_FORM_DATA);
 
         final MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
-        body.add("recipe", objectMapper.writeValueAsString(recipe));
+        body.add("recipe", objectMapper.writeValueAsString(recipeDto));
 
         HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
 
-        response = testRestTemplate.exchange(API_RECIPE, HttpMethod.PUT, requestEntity, Recipe.class);
-        recipe = requireNonNull(response.getBody());
+        response = testRestTemplate.exchange(API_RECIPE, HttpMethod.PUT, requestEntity, RecipeDto.class);
+        recipeDto = requireNonNull(response.getBody());
 
         // Scalar properties
-        assertThat(recipe.getName(), is("This is modified recipe name"));
-        assertThat(recipe.getDescription(), is("This is the modified description"));
-        assertThat(recipe.getCookingTime(), is(123));
-        assertThat(recipe.getImageFileName(), is("new_image.jpg"));
-        assertThat(recipe.getBasedOn(), is("http://www.random.com"));
-        assertThat(recipe.getLastUpdatedBy(), is("anonymousUser"));
-        assertThat(recipe.getCreatedBy(), is("anonymousUser"));
-        assertTrue(areWithinSeconds(recipe.getCreatedDate(), LocalDateTime.now(), 10));
-        assertTrue(areWithinSeconds(recipe.getLastUpdatedDate(), LocalDateTime.now(), 10));
+        assertThat(recipeDto.getDescription(), is("This is the modified description"));
+        assertThat(recipeDto.getCookingTime(), is(123));
+        assertThat(recipeDto.getBasedOn(), is("http://www.random.com"));
+        assertThat(recipeDto.getLastUpdatedBy(), is("anonymousUser"));
+        assertThat(recipeDto.getCreatedBy(), is("anonymousUser"));
+        assertTrue(areWithinSeconds(recipeDto.getCreatedDate(), LocalDateTime.now(), 10));
+        assertTrue(areWithinSeconds(recipeDto.getLastUpdatedDate(), LocalDateTime.now(), 10));
 
         // Notes
-        assertThat(recipe.getNotes().size(), is(2));
-        Note noteToCheck = recipe.getNotes().get(0);
+        assertThat(recipeDto.getNotes().size(), is(2));
+        Note noteToCheck = recipeDto.getNotes().get(0);
         assertThat(noteToCheck.getDescription(), is("Note 1 modified desc"));
         assertThat(noteToCheck.getOrdering(), is(69));
 
-        noteToCheck = recipe.getNotes().get(1);
+        noteToCheck = recipeDto.getNotes().get(1);
         assertThat(noteToCheck.getDescription(), is("New Note desc"));
         assertThat(noteToCheck.getOrdering(), is(420));
 
         // ServedOn
-        servedOn = recipe.getServedOn();
+        servedOn = recipeDto.getServedOn();
         assertThat(servedOn.isHeated(), is(false));
         assertThat(servedOn.getCrockery().getDescription(), is("White Plates"));
         assertThat(servedOn.getCrockery().getId(), is(1));
 
         // Tags
-        tags = recipe.getTags();
+        tags = recipeDto.getTags();
         assertThat(tags.size(), is(2));
         tag.setDescription("old-school");
         assertTrue(tags.contains(tag));
@@ -532,7 +529,7 @@ public class RestIntegrationTests {
         assertTrue(tags.contains(tag));
 
         // MethodSteps
-        methodSteps = recipe.getMethodSteps();
+        methodSteps = recipeDto.getMethodSteps();
         assertThat(methodSteps.size(), is(7));
         methodStep = methodSteps.get(0);
         assertThat(methodStep.getDescription(), is("Method Step modified desc"));
@@ -542,7 +539,7 @@ public class RestIntegrationTests {
         assertThat(methodStep.getOrdering(), is(321));
 
         // Ingredients
-        ingredients = recipe.getIngredients();
+        ingredients = recipeDto.getIngredients();
         assertThat(ingredients.size(), is(16));
 
         // Test the modified Ingredient
@@ -653,49 +650,49 @@ public class RestIntegrationTests {
     @Test
     @Order(400)
     public void testMarkRecipeAsDeleted() {
-        ResponseEntity<Recipe[]> allRecipesResponse = testRestTemplate.getForEntity(API_RECIPE, Recipe[].class);
+        ResponseEntity<RecipeDto[]> allRecipesResponse = testRestTemplate.getForEntity(API_RECIPE, RecipeDto[].class);
 
         // 7 recipes before "deletion"
-        Recipe[] recipes = requireNonNull(allRecipesResponse.getBody());
-        assertThat(recipes.length, equalTo(7));
+        RecipeDto[] recipeDtos = requireNonNull(allRecipesResponse.getBody());
+        assertThat(recipeDtos.length, equalTo(7));
 
         // "Delete" one
         HttpEntity<Void> httpEntity = new HttpEntity<>(null); // No body, No headers
-        int idToDelete = recipes[0].getId();
-        ResponseEntity<Recipe> deleteResponse =
+        int idToDelete = recipeDtos[0].getId();
+        ResponseEntity<RecipeDto> deleteResponse =
                 testRestTemplate.exchange(API_RECIPE + "/markAsDeleted/" + idToDelete,
                         HttpMethod.PUT,
                         httpEntity,
-                        Recipe.class);
+                        RecipeDto.class);
         assertThat(deleteResponse.getBody().isDeleted(), is(true));
 
         // Should only be 6 recipes now
-        allRecipesResponse = testRestTemplate.getForEntity(API_RECIPE, Recipe[].class);
-        recipes = requireNonNull(allRecipesResponse.getBody());
-        assertThat(recipes.length, equalTo(6));
+        allRecipesResponse = testRestTemplate.getForEntity(API_RECIPE, RecipeDto[].class);
+        recipeDtos = requireNonNull(allRecipesResponse.getBody());
+        assertThat(recipeDtos.length, equalTo(6));
     }
 
     @Test
     @Order(410)
     public void testRestore() {
-        ResponseEntity<Recipe[]> allRecipesResponse = testRestTemplate.getForEntity(API_RECIPE, Recipe[].class);
+        ResponseEntity<RecipeDto[]> allRecipesResponse = testRestTemplate.getForEntity(API_RECIPE, RecipeDto[].class);
 
         // 6 recipes before "restore"
-        Recipe[] recipes = requireNonNull(allRecipesResponse.getBody());
-        assertThat(recipes.length, equalTo(6));
+        RecipeDto[] recipeDtos = requireNonNull(allRecipesResponse.getBody());
+        assertThat(recipeDtos.length, equalTo(6));
 
         // Restore
         HttpEntity<Void> httpEntity = new HttpEntity<>(null); // No body, No headers
-        ResponseEntity<Recipe> restoreResponse =
+        ResponseEntity<RecipeDto> restoreResponse =
                 testRestTemplate.exchange(API_RECIPE + "/restore/" + 1,
                         HttpMethod.PUT,
                         httpEntity,
-                        Recipe.class);
+                        RecipeDto.class);
         assertThat(restoreResponse.getBody().isDeleted(), is(false));
 
         // Should be 7 recipes now
-        allRecipesResponse = testRestTemplate.getForEntity(API_RECIPE, Recipe[].class);
-        recipes = requireNonNull(allRecipesResponse.getBody());
-        assertThat(recipes.length, equalTo(7));
+        allRecipesResponse = testRestTemplate.getForEntity(API_RECIPE, RecipeDto[].class);
+        recipeDtos = requireNonNull(allRecipesResponse.getBody());
+        assertThat(recipeDtos.length, equalTo(7));
     }
 }

--- a/src/test/java/com/lstierneyltd/recipebackend/utils/TestConstants.java
+++ b/src/test/java/com/lstierneyltd/recipebackend/utils/TestConstants.java
@@ -39,6 +39,8 @@ public final class TestConstants {
     public static final String IDEA_NAME = "Idea Name";
     public static final String IDEA_URL = "https://www.bbcgoodfood.com/?IGNORE_GEO_REDIRECT_GLOBAL=true&v=1083955399";
 
+    public static final String BASE_IMAGE_FOLDER_PATH = "/opt/recipewebsite/images/";
+
 
 
     private TestConstants() {

--- a/src/test/java/com/lstierneyltd/recipebackend/utils/TestStubs.java
+++ b/src/test/java/com/lstierneyltd/recipebackend/utils/TestStubs.java
@@ -1,5 +1,7 @@
 package com.lstierneyltd.recipebackend.utils;
 
+import com.lstierneyltd.recipebackend.dto.RecipeDto;
+import com.lstierneyltd.recipebackend.dto.RecipePreviewDto;
 import com.lstierneyltd.recipebackend.entities.*;
 
 import java.util.ArrayList;
@@ -19,6 +21,43 @@ public final class TestStubs {
         unit.setName(NAME);
         unit.setAbbreviation(ABBREVIATION);
         return unit;
+    }
+
+    public static RecipeDto getRecipeDto() {
+        Recipe recipe = getRecipe();
+        return new RecipeDto.Builder()
+                .withId(recipe.getId())
+                .withName(recipe.getName())
+                .withDescription(recipe.getDescription())
+                .withCooked(recipe.getCooked())
+                .withLastCooked(recipe.getLastCooked())
+                .withCookingTime(recipe.getCookingTime())
+                .withBasedOn(recipe.getBasedOn())
+                .withMethodSteps(recipe.getMethodSteps())
+                .withIngredients(recipe.getIngredients())
+                .withNotes(recipe.getNotes())
+                .withTags(recipe.getTags())
+                .withServedOn(recipe.getServedOn())
+                .withDeleted(recipe.isDeleted())
+                .withImageFolderPath(BASE_IMAGE_FOLDER_PATH + recipe.getImageFolderName())
+                .withImageFileNames(List.of(RECIPE_1_IMAGE_FILENAME))
+                .withCreatedBy(CREATED_BY)
+                .withLastUpdatedBy(LAST_UPDATED_BY)
+                .withCreatedDate(CREATED_DATE)
+                .withLastUpdatedDate(LAST_UPDATED_DATE)
+                .build();
+    }
+
+    public static RecipePreviewDto getRecipePreviewDto() {
+        Recipe recipe = getRecipe();
+        return new RecipePreviewDto.Builder()
+                .withLastCooked(recipe.getLastCooked())
+                .withName(recipe.getName())
+                .withId(recipe.getId())
+                .withDescription(recipe.getDescription())
+                .withImageFileNames(List.of(RECIPE_1_IMAGE_FILENAME))
+                .withImageFolderPath(BASE_IMAGE_FOLDER_PATH)
+                .build();
     }
 
     public static Recipe getRecipe() {
@@ -42,7 +81,6 @@ public final class TestStubs {
         recipePreview.setId(ID);
         recipePreview.setDescription(DESCRIPTION);
         recipePreview.setName(NAME);
-        recipePreview.setImageFileName(RECIPE_1_IMAGE_FILENAME);
         return recipePreview;
     }
 


### PR DESCRIPTION
Refactor Recipe handling to utilize DTOs and remove imageFileName

Transitioned Recipe and RecipePreview entities to use corresponding DTOs, enhancing decoupling and clarity in service responses. Removed `imageFileName` field from entities and streamlined related methods. Updated integration and unit tests to align with the refactored structure.