### PR TITLE
MVR-184 Update PIT plugin and restore mutation testing config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <hsqldb.version>2.7.1</hsqldb.version>
         <java.version>17</java.version>
         <jjwt.version>0.9.1</jjwt.version>
-        <pitest.version>1.14.2</pitest.version>
+        <pitest.version>1.18.0</pitest.version>
         <mysql-connector-j.version>9.2.0</mysql-connector-j.version>
         <spring-boot-test-autoconfigure.version>3.0.3</spring-boot-test-autoconfigure.version>
         <maven-surefire-plugin.version>3.0.0-M9</maven-surefire-plugin.version>
@@ -184,27 +184,31 @@
                     </execution>
                 </executions>
             </plugin>
-            <!--            <plugin>-->
-            <!--                <groupId>org.pitest</groupId>-->
-            <!--                <artifactId>pitest-maven</artifactId>-->
-            <!--                <version>${pitest.version}</version>-->
-            <!--                <executions>-->
-            <!--                    <execution>-->
-            <!--                        <id>pit-report</id>-->
-            <!--                        <phase>verify</phase>-->
-            <!--                        <goals>-->
-            <!--                            <goal>mutationCoverage</goal>-->
-            <!--                        </goals>-->
-            <!--                    </execution>-->
-            <!--                </executions>-->
-            <!--                <dependencies>-->
-            <!--                    <dependency>-->
-            <!--                        <groupId>org.pitest</groupId>-->
-            <!--                        <artifactId>pitest-junit5-plugin</artifactId>-->
-            <!--                        <version>${pitest-junit5-plugin.version}</version>-->
-            <!--                    </dependency>-->
-            <!--                </dependencies>-->
-            <!--            </plugin>-->
+            <!--
+            mvn org.pitest:pitest-maven:mutationCoverage
+            Runs during "verify" phase
+            -->
+            <plugin>
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-maven</artifactId>
+                <version>${pitest.version}</version>
+                <executions>
+                    <execution>
+                        <id>pit-report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>mutationCoverage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.pitest</groupId>
+                        <artifactId>pitest-junit5-plugin</artifactId>
+                        <version>${pitest-junit5-plugin.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
         </plugins>
     </build>
 
@@ -230,18 +234,18 @@
                     </reportSet>
                 </reportSets>
             </plugin>
-            <!--            <plugin>-->
-            <!--                <groupId>org.pitest</groupId>-->
-            <!--                <artifactId>pitest-maven</artifactId>-->
-            <!--                <version>${pitest.version}</version>-->
-            <!--                <reportSets>-->
-            <!--                    <reportSet>-->
-            <!--                        <reports>-->
-            <!--                            <report>report</report>-->
-            <!--                        </reports>-->
-            <!--                    </reportSet>-->
-            <!--                </reportSets>-->
-            <!--            </plugin>-->
+            <plugin>
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-maven</artifactId>
+                <version>${pitest.version}</version>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>report</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
         </plugins>
     </reporting>
 </project>


### PR DESCRIPTION
Upgraded the PIT plugin to version 1.18.0 and fully restored its configuration in Maven. Mutation coverage will now execute during the `verify` phase, improving test effectiveness.